### PR TITLE
Add support for the `#to_param` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Identifiable makes it really simple to generate and use random public-facing IDs
 
 ```ruby
 # Before:
-orders_url(id: @order.id) # → https://example.app/orders/14
+orders_url(@order) # → https://example.app/orders/14
 
 # After:
-orders_url(id: @order.public_id) # → https://example.app/orders/87133275
+orders_url(@order) # → https://example.app/orders/87133275
 ```
 
 ## Installation

--- a/lib/identifiable/model.rb
+++ b/lib/identifiable/model.rb
@@ -117,10 +117,16 @@ module Identifiable
 
     # By overriding ActiveRecord's `#to_key`, this means that Rails' helpers,
     # such as `dom_id` will use the public ID instead of the regular ID when
-    # identifying the record. This also means when you do something like
-    # `orders_path(@order)`, it'll use the public ID for the `:id` URL param.
+    # identifying the record.
     def to_key
       [self[self.class.identifiable_column]]
+    end
+
+    # By overriding ActiveRecord's `#to_param`, this means that Rails' helpers,
+    # such as the `link_to` helpers will default to using the public ID
+    # instead of the regular ID when identifying the record.
+    def to_param
+      self[self.class.identifiable_column]
     end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -192,5 +192,17 @@ RSpec.describe Identifiable::Model do
         expect(user.to_key).not_to eq [user.id]
       end
     end
+
+    describe '#to_param' do
+      let(:user) { IdentifiedUser.create(name: 'Jane Doe') }
+
+      it 'returns the public id' do
+        expect(user.to_param).to eq user.public_id
+      end
+
+      it 'does not return the standard id' do
+        expect(user.to_param).not_to eq user.id.to_s
+      end
+    end
   end
 end


### PR DESCRIPTION
We supported `#to_key`, which gave us support for public IDs in view helpers like the `dom_id` helper, but for some reason `#to_param` isn't based off `#to_key`, so we need to implement it separately.