### PR TITLE
Recover when there's not a table yet

### DIFF
--- a/lib/identifiable/model.rb
+++ b/lib/identifiable/model.rb
@@ -54,6 +54,9 @@ module Identifiable
       # The column parameter must be in the model's table, so check that the
       # column corresponds to a column in the model's table, and raise an error
       # if it is not.
+      #
+      # We suppress ActiveRecord::StatmentInvalid errors just in case the table
+      # does not exist yet.
       # rubocop:disable Lint/SuppressedException
       def _identifiable_validate_column_must_be_in_the_table
         return if column_names.include? @identifiable_column.to_s

--- a/lib/identifiable/model.rb
+++ b/lib/identifiable/model.rb
@@ -54,11 +54,14 @@ module Identifiable
       # The column parameter must be in the model's table, so check that the
       # column corresponds to a column in the model's table, and raise an error
       # if it is not.
+      # rubocop:disable Lint/SuppressedException
       def _identifiable_validate_column_must_be_in_the_table
         return if column_names.include? @identifiable_column.to_s
 
         raise Identifiable::Errors::ColumnMustExistInTheTableError.new(@identifiable_column, valid_columns: column_names)
+      rescue ActiveRecord::StatementInvalid
       end
+      # rubocop:enable Lint/SuppressedException
 
       # We can only use valid styles, so check that the style parameter is a
       # valid style, and raise an error if it is not.


### PR DESCRIPTION
My thanks to Ahmad Younis for reporting this issue:

> Steps to reproduce:
> 1. Create a new rails app pg db
> 2. Add devise gem and generate the user model
> 3. add identifiable gem
> 4. run the migrations
> 
> Expected behavior: The migration will run
> Actual behaviour: Migration fails with the following error:
> ```
> ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "users" does not exist
> LINE 9:  WHERE a.attrelid = '"users"'::regclass
> 
> Caused by:
> PG::UndefinedTable: ERROR:  relation "users" does not exist
> LINE 9:  WHERE a.attrelid = '"users"'::regclass
> 
> user.rb:
> 
> class User < ApplicationRecord
>   identifiable style: :numeric, length: 10
> 
>   devise :database_authenticatable, :registerable,
>          :recoverable, :rememberable, :validatable
> end
> ```

This PR suppresses the `ActiveRecord::StatementInvalid` error, so we don't raise an error if the table doesn't exist yet, we only raise an error when the column doesn't exist on an existing table.